### PR TITLE
Fix file_check docstring

### DIFF
--- a/neupan/util/__init__.py
+++ b/neupan/util/__init__.py
@@ -57,18 +57,22 @@ def time_it(name="Function"):
 
 
 def file_check(file_name):
-    """
-    Check whether a file exists and return its absolute path.
+    """Return the absolute path for ``file_name`` if it exists.
+
+    The function looks for the file in the following order:
+    ``file_name`` as given, ``sys.path[0]``, ``os.getcwd()``, and finally the
+    NeuPAN package root derived from ``neupan.__file__``. If the file is not
+    found in any of these locations a :class:`FileNotFoundError` is raised.
 
     Args:
-        file_name (str): Name of the file to check.
-        root_path (str, optional): Root path to use if the file is not found.
+        file_name (str): Name of the file to locate.
 
     Returns:
         str: Absolute path of the file if found.
 
     Raises:
-        FileNotFoundError: If the file is not found.
+        FileNotFoundError: If the file does not exist in any of the searched
+            directories.
     """
 
     root_path = os.path.dirname(os.path.dirname(neupan.__file__))


### PR DESCRIPTION
## Summary
- remove reference to nonexistent `root_path` parameter
- clarify search order and error raising behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685981b8af0c83248e846e6051338571

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

文档：
- 移除对不存在的 `root_path` 参数的引用，并在其文档字符串中阐明 `file_check` 的搜索顺序和引发错误的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Remove reference to nonexistent root_path parameter and clarify file_check search order and error raising behavior in its docstring

</details>