### PR TITLE
Fix duplicate numpy import

### DIFF
--- a/neupan/blocks/pan.py
+++ b/neupan/blocks/pan.py
@@ -23,7 +23,6 @@ from neupan.blocks import NRMP, DUNE
 import numpy as np
 from math import inf
 from typing import Optional
-import numpy as np
 from neupan.configuration import to_device, tensor_to_np
 from neupan.util import downsample_decimation
 


### PR DESCRIPTION
## Summary
- remove repeated `numpy` import in `pan.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68599174bb188324947a3da0e92c97e8

好的，这是将给定的 pull request 总结翻译成中文的结果：

## Sourcery 总结

Bug 修复:
- 移除 pan.py 中重复导入 numpy 的语句

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Eliminate duplicate import of numpy in pan.py

</details>