### PR TITLE
Add baseline retrieval script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ cd NeuPAN
 pip install -e .  
 ```
 
+## Baseline Setup
+
+To download baseline implementations referenced in the paper, run:
+
+```bash
+bash scripts/fetch_baselines.sh
+```
+
+This clones available repositories into `baselines/`. See [baselines/README.md](baselines/README.md) for details on additional baselines.
+
 ## Run Examples on IR-SIM
 
 Please Install [IR-SIM](https://github.com/hanruihua/ir-sim) first by:

--- a/baselines/README.md
+++ b/baselines/README.md
@@ -1,0 +1,19 @@
+# Baselines
+
+This directory is intended to hold baseline implementations used for comparison with NeuPAN.
+
+## Downloading
+
+Run the following script to clone open-source baseline repositories:
+
+```bash
+bash scripts/fetch_baselines.sh
+```
+
+Currently, the script fetches:
+
+- [TEB Local Planner](https://github.com/rst-tu-dortmund/teb_local_planner)
+- [AEMCARL](https://github.com/SJWang2015/AEMCARL)
+
+Other baselines such as RDA, Falco, OBCA, and STT require manual setup or do not have publicly available code. Place their
+implementations under this directory as needed and follow their individual build instructions.

--- a/scripts/fetch_baselines.sh
+++ b/scripts/fetch_baselines.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Fetch baseline algorithms referenced in the NeuPAN paper.
+# Clones available public repositories into the baselines/ directory.
+set -e
+
+mkdir -p baselines
+cd baselines
+
+# Clone TEB local planner (ROS-based)
+if [ ! -d teb_local_planner ]; then
+  git clone https://github.com/rst-tu-dortmund/teb_local_planner.git
+fi
+
+# Clone AEMCARL repository
+if [ ! -d AEMCARL ]; then
+  git clone https://github.com/SJWang2015/AEMCARL.git
+fi
+
+# TODO: add repositories for RDA, Falco, OBCA, STT and others when available.


### PR DESCRIPTION
## Summary
- add `fetch_baselines.sh` script to download open-source baseline planners
- document baseline directory and setup instructions
- mention baseline setup in main README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf7e70f1b08324ba30cca48b886592

## Sourcery 总结

添加一个脚本来自动化下载开源基线规划器，并文档化基线目录结构和设置说明

新功能：
- 添加 `fetch_baselines.sh` 脚本，将 `TEB Local Planner` 和 `AEMCARL` 仓库克隆到 `baselines/` 中

文档：
- 创建 `baselines/README.md`，用于文档化可用的基线以及其他基线的手动设置方法
- 更新主 `README`，以包含基线设置说明并链接到 `baselines/README.md`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a script to automate downloading of open-source baseline planners and document the baseline directory structure and setup instructions

New Features:
- Add fetch_baselines.sh script to clone TEB Local Planner and AEMCARL repositories into baselines/

Documentation:
- Create baselines/README.md to document available baselines and manual setup for others
- Update main README to include baseline setup instructions and link to baselines/README.md

</details>