### PR TITLE
Add baseline retrieval script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ cd NeuPAN
 pip install -e .  
 ```
 
+## Baseline Setup
+
+To download baseline implementations referenced in the paper, run:
+
+```bash
+bash scripts/fetch_baselines.sh
+```
+
+This clones available repositories (TEB, AEMCARL, and OBCA) into `baselines/`. See [baselines/README.md](baselines/README.md) for details on additional baselines.
+
 ## Run Examples on IR-SIM
 
 Please Install [IR-SIM](https://github.com/hanruihua/ir-sim) first by:

--- a/baselines/README.md
+++ b/baselines/README.md
@@ -1,0 +1,20 @@
+# Baselines
+
+This directory is intended to hold baseline implementations used for comparison with NeuPAN.
+
+## Downloading
+
+Run the following script to clone open-source baseline repositories:
+
+```bash
+bash scripts/fetch_baselines.sh
+```
+
+Currently, the script fetches:
+
+- [TEB Local Planner](https://github.com/rst-tu-dortmund/teb_local_planner)
+- [AEMCARL](https://github.com/SJWang2015/AEMCARL)
+- [OBCA](https://github.com/XiaojingGeorgeZhang/OBCA)
+
+Other baselines such as RDA, Falco, and STT require manual setup or do not have publicly available code. Place their
+implementations under this directory as needed and follow their individual build instructions.

--- a/scripts/fetch_baselines.sh
+++ b/scripts/fetch_baselines.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Fetch baseline algorithms referenced in the NeuPAN paper.
+# Clones available public repositories into the baselines/ directory.
+
+set -e
+
+mkdir -p baselines
+cd baselines
+
+clone_repo() {
+  repo_url=$1
+  dir_name=$2
+  if [ ! -d "$dir_name" ]; then
+    git clone --depth 1 "$repo_url" "$dir_name"
+  else
+    echo "$dir_name already exists, skipping"
+  fi
+}
+
+# Clone TEB local planner (ROS-based)
+clone_repo https://github.com/rst-tu-dortmund/teb_local_planner.git teb_local_planner
+
+# Clone AEMCARL repository
+clone_repo https://github.com/SJWang2015/AEMCARL.git AEMCARL
+
+# Clone OBCA repository
+clone_repo https://github.com/XiaojingGeorgeZhang/OBCA.git OBCA
+
+echo "RDA, Falco, and STT baselines either lack public code or require manual setup."


### PR DESCRIPTION
## Summary
- automate cloning of TEB, AEMCARL, and OBCA baseline repositories
- document available and manual baselines in README files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf7e70f1b08324ba30cca48b886592